### PR TITLE
CI: Configure codecov not to comment.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+# show coverage in CI status, not as a comment. 
+comment: off
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+    patch:
+      default:
+        target: auto


### PR DESCRIPTION
I ran across this configuration file on Twitter it seemed like it might be a
good fit for us also. It shows the Coverage in the integrations but does not
comment (as long as all is well).

I thought we might take it for a spin here and add it to our more-established
repos consistently if we like it. Feedback welcome!