### PR TITLE
BLD: Install tests subpackage.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     long_description=readme,
-    packages=['suitcase.utils'],
+    packages=['suitcase.utils', 'suitcase.utils.tests'],
     entry_points={
         'console_scripts': [
             # 'some.module:some_function',


### PR DESCRIPTION
Without this, pip-installed suitcase-utils does not expose
``suitcase.utils.tests``.