### PR TITLE
FIX: Do not expose a *copy* of artifacts; expose artifacts.

### DIFF
--- a/suitcase/utils/__init__.py
+++ b/suitcase/utils/__init__.py
@@ -39,14 +39,10 @@ class MultiFileManager:
     This design is inspired by Python's zipfile and tarfile libraries.
     """
     def __init__(self, directory):
+        self.artifacts = collections.defaultdict(list)
         self._directory = Path(directory)
         self._reserved_names = set()
-        self._artifacts = collections.defaultdict(list)
         self._files = []
-
-    @property
-    def artifacts(self):
-        return dict(self._artifacts)
 
     def reserve_name(self, label, postfix):
         """
@@ -75,7 +71,7 @@ class MultiFileManager:
             raise SuitcaseUtilsValueError(
                 f"The postfix {postfix!r} has already been used.")
         self._reserved_names.add(name)
-        self._artifacts[label].append(name)
+        self.artifacts[label].append(name)
         return name
 
     def open(self, label, postfix, mode, encoding=None, errors=None):
@@ -160,35 +156,9 @@ class MemoryBuffersManager:
     buffers created.
     """
     def __init__(self):
+        self.artifacts = collections.defaultdict(list)
         self._reserved_names = set()
-        self._artifacts = collections.defaultdict(list)
         self.buffers = {}  # maps postfixes to buffer objects
-
-    @property
-    def artifacts(self):
-        return dict(self. _artifacts)
-
-    def reserve_name(self, label, postfix):
-        """
-        Ask the wrapper for a filepath.
-
-        An external library that needs a filepath (not a handle)
-        may use this instead of the ``open`` method.
-
-        Parameters
-        -------
-        label : string
-            partial file name (i.e. stream name)
-        postfix : string
-            relative file path and filename
-
-        Returns
-        ----------
-        filepath : Path
-        """
-        raise SuitcaseUtilsTypeError(
-            "MemoryBuffersManager is incompatible with exporters that require "
-            "explicit filenames.")
 
     def open(self, label, postfix, mode, encoding=None, errors=None):
         """
@@ -233,7 +203,7 @@ class MemoryBuffersManager:
             raise ModeError(
                 f"The mode passed to MemoryBuffersManager.open is {mode} but "
                 f"needs to be one of 'x', 'xt' or 'xb'.")
-        self._artifacts[label].append(buffer)
+        self.artifacts[label].append(buffer)
         self.buffers[postfix] = buffer
         return buffer
 

--- a/suitcase/utils/__init__.py
+++ b/suitcase/utils/__init__.py
@@ -31,8 +31,8 @@ class MultiFileManager:
     """
     A class that manages multiple files.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     directory : str or Path
         The directory (as a string or as a Path) to create teh files inside.
 
@@ -54,9 +54,10 @@ class MultiFileManager:
         Parameters
         ----------
         label : string
-            partial file name (i.e. stream name)
+            A label for the sort of content being stored, such as
+            'stream_data' or 'metadata'.
         postfix : string
-            relative file path and filename
+            Postfix for the file name. Must be unique for this Manager.
 
         Returns
         -------
@@ -81,15 +82,16 @@ class MultiFileManager:
         Like the built-in open function, this may be used as a context manager.
 
         Parameters
-        -------
+        ----------
         label : string
-            partial file name (i.e. stream name)
+            A label for the sort of content being stored, such as
+            'stream_data' or 'metadata'.
         postfix : string
-            postfix for the filenames.
+            Postfix for the file name. Must be unique for this Manager.
         mode : {'x', 'xt', xb'}
             'x' or 'xt' for text, 'xb' for binary
         encoding : string or None
-            Passed through open.  See Python open documentation for allowed
+            Passed through open. See Python open documentation for allowed
             values. Only applicable to text mode.
         errors : string or None
             Passed through to open. See Python open documentation for allowed
@@ -167,11 +169,13 @@ class MemoryBuffersManager:
         Like the built-in open function, this may be used as a context manager.
 
         Parameters
-        -------
+        ----------
         label : string
-            partial file name (i.e. stream name)
+            A label for the sort of content being stored, such as
+            'stream_data' or 'metadata'.
         postfix : string
-            relative file path and filename
+            Relative file path (simply used as an identifer in this case, as
+            there is no actual file). Must be unique for this Manager.
         mode : {'x', 'xt', xb'}
             'x' or 'xt' for text, 'xb' for binary
         encoding : string or None

--- a/suitcase/utils/tests/tests.py
+++ b/suitcase/utils/tests/tests.py
@@ -43,9 +43,8 @@ def test_memory_buffers_basic_operation():
     manager = MemoryBuffersManager()
     f = manager.open('thing', 'stuff', 'x')
 
-    # Check that reserve_name fails explicitly on MemoryBuffersManager.
-    with pytest.raises(SuitcaseUtilsTypeError):
-        manager.reserve_name('thing', 'stuff')
+    # Check that reserve_name is not defined on MemoryBuffersManager.
+    assert not hasattr(manager, 'reserve_name')
 
     # Check that name clashes are not allowed.
     with pytest.raises(SuitcaseUtilsValueError):


### PR DESCRIPTION
The Serializers end up with a reference to an (empty) copy of the artifacts
dict before any data was added to it.