### PR TITLE
BLD: bluesky and ophyd are required for test fixtures.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ with open(path.join(here, 'requirements.txt')) as requirements_file:
 
 
 extras_require = {
-    'test_fixtures': ['attrs >= 18.1.0', 'caproto', 'curio', 'pytest >=3.9',
-                      'trio']
+    'test_fixtures': ['attrs >= 18.1.0', 'bluesky', 'caproto', 'curio',
+                      'ophyd', 'pytest >=3.9', 'trio']
 }
 
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))


### PR DESCRIPTION
We actually need an unmerged branch of ophyd, but we have to handle
that in ``requirements-dev.txt`` in the downstream packages. When
the required update to ophyd is finally released, this will be good to
go and downstream packages can remove the special dependency in their
``requirements-dev.txt`` at their leisure.