### PR TITLE
TST: added missing pytest dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ with open(path.join(here, 'requirements.txt')) as requirements_file:
 
 
 extras_require = {
-    'test_fixtures': ['attrs >= 18.1.0', 'bluesky', 'caproto', 'curio',
-                      'ophyd', 'pytest >=3.9', 'trio']
+    'test_fixtures': ['asv', 'attrs >= 18.1.0', 'bluesky', 'caproto', 'curio',
+                      'ophyd', 'pytest >=3.9', 'pytest-benchmark', 'trio']
 }
 
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))


### PR DESCRIPTION
Replaces https://github.com/NSLS-II/suitcase-tiff/pull/12.

The message also appears on Travis: https://travis-ci.org/NSLS-II/suitcase-tiff/builds/492291104#L618.