### PR TITLE
ENH: add direct_img_list producing a 10x10 list, not np.ndarray

### DIFF
--- a/suitcase/utils/tests/conftest.py
+++ b/suitcase/utils/tests/conftest.py
@@ -49,7 +49,8 @@ def one_stream_multi_descriptors_plan(dets):
     yield from _internal_plan(dets)
 
 
-@pytest.fixture(params=['det', 'direct_img', 'det direct_img'],
+@pytest.fixture(params=['det', 'direct_img', 'direct_img_list',
+                        'det direct_img'],
                 scope='function')
 def detector_list(hw, request):  # noqa
 

--- a/suitcase/utils/tests/conftest.py
+++ b/suitcase/utils/tests/conftest.py
@@ -50,7 +50,7 @@ def one_stream_multi_descriptors_plan(dets):
 
 
 @pytest.fixture(params=['det', 'direct_img', 'direct_img_list',
-                        'det direct_img'],
+                        'det direct_img direct_img_list'],
                 scope='function')
 def detector_list(hw, request):  # noqa
 


### PR DESCRIPTION
This depends on https://github.com/NSLS-II/ophyd/pull/682/commits/a38fa6f3b1231fadd67b0ddd2d417e5cd3bfde59.