### PR TITLE
ENH: add pytest fixtures for testing the file_prefix and directory formatting

### DIFF
--- a/suitcase/utils/tests/conftest.py
+++ b/suitcase/utils/tests/conftest.py
@@ -211,3 +211,30 @@ def example_data(generate_data, plan_type):
         return generate_data(plan_type(ignore), ignore=ignore)
 
     return _example_data_func
+
+
+@pytest.fixture(params=['test-', 'scan_{uid}-'],
+                scope='function')
+def file_prefix_list(request):  # noqa
+    '''Returns a list file_prefixes to be formatted for testing.
+    '''
+
+    def _file_prefix_list_func(ignore=[]):
+        if request.param in ignore:
+            pytest.skip()
+        return request.param
+
+    return _file_prefix_list_func
+
+
+@pytest.fixture(params=['', '/test', '/scan_{uid}'],
+                scope='function')
+def directory_list(request):  # noqa
+    '''Returns a list of directories to be formatted for testing.
+    '''
+    def _directory_list_func(ignore=[]):
+        if request.param in ignore:
+            pytest.skip()
+        return request.param
+
+    return _directory_list_func

--- a/suitcase/utils/tests/conftest.py
+++ b/suitcase/utils/tests/conftest.py
@@ -216,7 +216,7 @@ def example_data(generate_data, plan_type):
 @pytest.fixture(params=['test-', 'scan_{uid}-'],
                 scope='function')
 def file_prefix_list(request):  # noqa
-    '''Returns a list file_prefixes to be formatted for testing.
+    '''Returns a function that provides file_prefixes for testing.
     '''
 
     def _file_prefix_list_func(ignore=[]):
@@ -230,7 +230,7 @@ def file_prefix_list(request):  # noqa
 @pytest.fixture(params=['', '/test', '/scan_{uid}'],
                 scope='function')
 def directory_list(request):  # noqa
-    '''Returns a list of directories to be formatted for testing.
+    '''Returns a function that provides directories for testing.
     '''
     def _directory_list_func(ignore=[]):
         if request.param in ignore:


### PR DESCRIPTION
This adds some pytest.fixtures that can be used for testing the formatting of the file_prefix and the directory for most suitcase repos.